### PR TITLE
针对Windows运行进行的修改

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ configs/vhap_tracking/
 exps/
 pretrain_model/
 pretrained_models/
+.glut/
+*.bat
+external/landmark_detection/FaceBoxesV2/utils/nms/cpu_nms.cp310-win_amd64.pyd
+/external/landmark_detection/FaceBoxesV2/utils/build
+/tracking_output
+external/landmark_detection/FaceBoxesV2/utils/nms/cpu_nms.c

--- a/app_lam.py
+++ b/app_lam.py
@@ -38,8 +38,11 @@ try:
 except:
     pass
 
+from pathlib import Path
 
 h5_rendering = False  # True
+torch._dynamo.config.suppress_errors = True  # 禁用动态编译错误
+torch._dynamo.config.disable = True
 
 
 def launch_env_not_compile_with_cuda():
@@ -249,7 +252,7 @@ def demo_lam(flametracking, lam, cfg):
         assert (return_code == 0), "flametracking export failed!"
 
         image_path = os.path.join(output_dir, "images/00000_00.png")
-        mask_path = os.path.join(output_dir, "/fg_masks/00000_00.png")
+        mask_path = os.path.join(output_dir, "fg_masks/00000_00.png")
         print(image_path, mask_path)
 
         aspect_standard = 1.0/1.0
@@ -267,8 +270,8 @@ def demo_lam(flametracking, lam, cfg):
         Image.fromarray(vis_ref_img).save(save_ref_img_path)
 
         # prepare motion seq
-        src = image_path.split('/')[-3]
-        driven = motion_seqs_dir.split('/')[-2]
+        src = Path(image_path).parent.parent.name
+        driven = Path(motion_seqs_dir).parent.name
         src_driven = [src, driven]
         motion_seq = prepare_motion_seqs(motion_seqs_dir, None, save_root=dump_tmp_dir, fps=render_fps,
                                             bg_color=1., aspect_standard=aspect_standard, enlarge_ratio=[1.0, 1,0],

--- a/app_lam.py
+++ b/app_lam.py
@@ -249,7 +249,7 @@ def demo_lam(flametracking, lam, cfg):
         assert (return_code == 0), "flametracking export failed!"
 
         image_path = os.path.join(output_dir, "images/00000_00.png")
-        mask_path = image_path.replace("/images/", "/fg_masks/").replace(".jpg", ".png")
+        mask_path = os.path.join(output_dir, "/fg_masks/00000_00.png")
         print(image_path, mask_path)
 
         aspect_standard = 1.0/1.0

--- a/configs/vhap_tracking/base_tracking_config.yaml
+++ b/configs/vhap_tracking/base_tracking_config.yaml
@@ -5,7 +5,7 @@
   \ star\n  n_downsample_rgb: null\n  root_folder: ''\n  scale_factor: 1.0\n  sequence:\
   \ ''\n  subset: null\n  target_extrinsic_type: w2c\n  use_alpha_map: false\n  use_landmark:\
   \ true\ndevice: cuda\nexp: !dataclass:ExperimentConfig\n  keyframes: !!python/tuple\
-  \ []\n  output_folder: !!python/object/apply:pathlib.PosixPath\n  - output\n  -\
+  \ []\n  output_folder: !!python/object/apply:pathlib.Path\n  - output\n  -\
   \ track\n  photometric: false\n  reuse_landmarks: true\nlog: !dataclass:LogConfig\n\
   \  image_format: jpg\n  interval_media: 500\n  interval_scalar: 100\n  max_num_views:\
   \ 3\n  stack_views_in_rows: true\n  view_indices: !!python/tuple []\nlr: !dataclass:LearningRateConfig\n\

--- a/external/landmark_detection/FaceBoxesV2/utils/build.py
+++ b/external/landmark_detection/FaceBoxesV2/utils/build.py
@@ -44,7 +44,7 @@ ext_modules = [
         "nms.cpu_nms",
         ["nms/cpu_nms.pyx"],
         # extra_compile_args={'gcc': ["-Wno-cpp", "-Wno-unused-function"]},
-        extra_compile_args=["-Wno-cpp", "-Wno-unused-function"],
+        extra_compile_args=[],
         include_dirs=[numpy_include]
     )
 ]

--- a/external/landmark_detection/FaceBoxesV2/utils/nms/cpu_nms.pyx
+++ b/external/landmark_detection/FaceBoxesV2/utils/nms/cpu_nms.pyx
@@ -5,6 +5,9 @@
 # Written by Ross Girshick
 # --------------------------------------------------------
 
+# cython: language_level=3
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION 
+
 import numpy as np
 cimport numpy as np
 
@@ -14,7 +17,7 @@ cdef inline np.float32_t max(np.float32_t a, np.float32_t b):
 cdef inline np.float32_t min(np.float32_t a, np.float32_t b):
     return a if a <= b else b
 
-def cpu_nms(np.ndarray[np.float32_t, ndim=2] dets, np.float thresh):
+def cpu_nms(np.ndarray[np.float32_t, ndim=2] dets, float thresh):
     cdef np.ndarray[np.float32_t, ndim=1] x1 = dets[:, 0]
     cdef np.ndarray[np.float32_t, ndim=1] y1 = dets[:, 1]
     cdef np.ndarray[np.float32_t, ndim=1] x2 = dets[:, 2]
@@ -22,11 +25,10 @@ def cpu_nms(np.ndarray[np.float32_t, ndim=2] dets, np.float thresh):
     cdef np.ndarray[np.float32_t, ndim=1] scores = dets[:, 4]
 
     cdef np.ndarray[np.float32_t, ndim=1] areas = (x2 - x1 + 1) * (y2 - y1 + 1)
-    cdef np.ndarray[np.int_t, ndim=1] order = scores.argsort()[::-1]
+    cdef np.ndarray[np.int32_t, ndim=1] order = scores.argsort()[::-1].astype(np.int32)
 
     cdef int ndets = dets.shape[0]
-    cdef np.ndarray[np.int_t, ndim=1] suppressed = \
-            np.zeros((ndets), dtype=np.int)
+    cdef np.ndarray[np.int32_t, ndim=1] suppressed = np.zeros((ndets), dtype=np.int32) 
 
     # nominal indices
     cdef int _i, _j

--- a/external/landmark_detection/FaceBoxesV2/utils/nms_wrapper.py
+++ b/external/landmark_detection/FaceBoxesV2/utils/nms_wrapper.py
@@ -7,9 +7,11 @@
 
 from .nms.cpu_nms import cpu_nms, cpu_soft_nms
 
+import numpy as np 
+
 def nms(dets, thresh):
     """Dispatch to either CPU or GPU NMS implementations."""
 
     if dets.shape[0] == 0:
         return []
-    return cpu_nms(dets, thresh)
+    return cpu_nms(dets.astype(np.float32), float(thresh))

--- a/external/vgghead_detector/VGGDetector.py
+++ b/external/vgghead_detector/VGGDetector.py
@@ -21,7 +21,7 @@ class VGGHeadDetector(torch.nn.Module):
 
     def _init_models(self,):
         # vgg_heads_l
-        self.model = torch.load(self.vggheadmodel_path, map_location='cpu')
+        self.model = torch.load(self.vggheadmodel_path, map_location='cpu', weights_only=False)
         self.model.to(self._device).eval()
 
     @torch.no_grad()

--- a/tools/flame_tracking_single_image.py
+++ b/tools/flame_tracking_single_image.py
@@ -249,7 +249,7 @@ class FlameTrackingSingleImage:
             config_data = safe_load(yml_f)
         config_data = tyro.from_yaml(BaseTrackingConfig, config_data)
 
-        config_data.data.sequence = self.sub_output_dir.split('/')[-1]
+        config_data.data.sequence = Path(self.sub_output_dir).name 
         config_data.data.root_folder = Path(
             os.path.dirname(self.sub_output_dir))
 
@@ -328,7 +328,7 @@ class FlameTrackingSingleImage:
 
         src_folder = Path(self.output_tracking)
         tgt_folder = Path(self.output_export,
-                          self.sub_output_dir.split('/')[-1])
+                          Path(self.sub_output_dir).name)
         src_folder, config_data = load_config(src_folder)
 
         nerf_writer = NeRFDatasetWriter(config_data.data, tgt_folder, None,


### PR DESCRIPTION
修改内容按照实际运行中，产生报错，并修复的时间顺序进行排列：
1.删除了build.py中，Windows不支持的编译命令
2.同时修改了cpu_nms.pyx和nms_wrapper.py，限定了cython的版本，并调整了正确的传参精度 
3.在VGGDetector.py添加了torch在2.6.0版本后需要的参数
4.修改了base_tracking_config.yaml中，Windows不支持的PosixPath 
5.将flame_tracking_single_image.py和app_lam.py文件中，split('/')[-n]改为了更通用的写法 
6.在app_lam.py添加了禁用动态编译，这样就不需要triton了